### PR TITLE
Delegating Administration actions to specific admin

### DIFF
--- a/Admin/AdminBlock.php
+++ b/Admin/AdminBlock.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Alpixel\Bundle\CMSBundle\Admin;
+
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+class AdminBlock extends BaseBlockEntityAdmin
+{
+    protected $baseRouteName = 'alpixel_admin_cms_block';
+    protected $baseRoutePattern = 'block';
+
+    protected $datagridValues = [
+        '_page'       => 1,
+        '_sort_order' => 'DESC',
+        '_sort_by'    => 'dateUpdated',
+    ];
+
+    protected function configureRoutes(RouteCollection $collection)
+    {
+        $collection->clearExcept(['list', 'edit']);
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Datagrid\ListMapper $listMapper
+     *
+     * @return void
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->add('id')
+            ->add('locale', null, [
+                'label' => 'Langue',
+            ])
+            ->add('name', null, [
+                'label' => 'Nom',
+            ])
+            ->add('dateCreated', null, [
+                'label' => 'Date de création',
+            ])
+            ->add('dateUpdated', null, [
+                'label' => 'Date d\'édition',
+            ])
+            ->add('_action', 'actions', [
+                'actions' => [
+                    'edit' => ['template' => 'AlpixelCMSBundle:admin:fields/list__block_action_edit.html.twig'],
+                ],
+            ]);
+    }
+}

--- a/Admin/AdminNode.php
+++ b/Admin/AdminNode.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Alpixel\Bundle\CMSBundle\Admin;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+
+class AdminNode extends BaseAdmin
+{
+    protected $baseRouteName = 'alpixel_admin_cms_node';
+    protected $baseRoutePattern = 'node';
+    protected $classnameLabel = 'pages';
+
+    protected $datagridValues = [
+        '_page'       => 1,
+        '_sort_order' => 'DESC',
+        '_sort_by'    => 'dateUpdated',
+    ];
+
+    protected function configureRoutes(RouteCollection $collection)
+    {
+        $collection->clearExcept(['list']);
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $datagridMapper
+     *
+     * @return void
+     */
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $container = $this->getConfigurationPool()->getContainer();
+        $entityManager = $container->get('doctrine.orm.default_entity_manager');
+        $datagridMapper
+            ->add('locale', 'doctrine_orm_callback', [
+                'label'    => 'Langue',
+                'callback' => function (ProxyQuery $queryBuilder, $alias, $field, $value) {
+                    if (!$value['value']) {
+                        return false;
+                    }
+                    $queryBuilder
+                        ->andWhere($alias.'.locale = :locale')
+                        ->setParameter('locale', $value['value']);
+
+                    return true;
+                },
+            ],
+                'choice',
+                [
+                    'choices' => $this->getRealLocales(),
+                ])
+            ->add('title', null, [
+                'label' => 'Page',
+            ])
+            ->add('published', null, [
+                'label' => 'Publié',
+            ])
+            ->add('node', 'doctrine_orm_callback', [
+                'label'    => 'Type de contenu',
+                'callback' => function (ProxyQuery $queryBuilder, $alias, $field, $value) use ($entityManager) {
+                    if (!$value['value']) {
+                        return false;
+                    }
+                    // We can't query the type from the AlpixelCMSBundle:Node repository (InheritanceType) because of that
+                    // we try to get the repository in AppBundle with the value which is the class name of entity. :pig:
+                    try {
+                        $repository = $entityManager->getRepository(sprintf('AppBundle:%s', ucfirst($value['value'])));
+                    } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
+                        return false;
+                    }
+                    $data = $repository->findAll();
+                    if (empty($data)) {
+                        return false;
+                    }
+                    $queryBuilder
+                        ->andWhere($alias.'.id IN (:ids)')
+                        ->setParameter('ids', $data);
+
+                    return true;
+                },
+            ],
+                'choice',
+                [
+                    'choices' => $this->getCMSEntityTypes(),
+                ]
+            );
+    }
+
+    /**
+     * @param \Sonata\AdminBundle\Datagrid\ListMapper $listMapper
+     *
+     * @return void
+     */
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->add('id')
+            ->add('locale', null, [
+                'label' => 'Langue',
+            ])
+            ->add('title', null, [
+                'label' => 'Page',
+            ])
+            ->add('type', null, [
+                'label'    => 'Type',
+                'template' => 'AlpixelCMSBundle:admin:fields/list__field_type.html.twig',
+            ])
+            ->add('dateCreated', null, [
+                'label' => 'Date de création',
+            ])
+            ->add('dateUpdated', null, [
+                'label' => 'Date d\'édition',
+            ])
+            ->add('published', null, [
+                'label' => 'Publié',
+            ])
+            ->add('_action', 'actions', [
+                'actions' => [
+                    'see'    => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_see.html.twig'],
+                    'edit'   => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_edit.html.twig'],
+                    'delete' => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_delete.html.twig'],
+                ],
+            ]);
+    }
+
+    public function buildBreadcrumbs($action, MenuItemInterface $menu = null)
+    {
+        if (isset($this->breadcrumbs[$action])) {
+            return $this->breadcrumbs[$action];
+        }
+
+        $menu = $this->menuFactory->createItem('root');
+
+        $menu = $menu->addChild('Dashboard',
+            ['uri' => $this->routeGenerator->generate('sonata_admin_dashboard')]
+        );
+
+        $menu = $menu->addChild('Gestion des pages',
+            ['uri' => $this->routeGenerator->generate('alpixel_admin_cms_node_list')]
+        );
+
+        return $this->breadcrumbs[$action] = $menu;
+    }
+}

--- a/Admin/BaseBlockEntityAdmin.php
+++ b/Admin/BaseBlockEntityAdmin.php
@@ -2,7 +2,6 @@
 
 namespace Alpixel\Bundle\CMSBundle\Admin;
 
-use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -21,8 +20,7 @@ class BaseBlockEntityAdmin extends BaseAdmin
 
     protected function configureRoutes(RouteCollection $collection)
     {
-        $collection->clearExcept(['list', 'delete', 'edit']);
-        $collection->add('editContent', $this->getRouterIdParameter().'/edit/block');
+        $collection->clearExcept(['edit']);
     }
 
     protected function configureFormFields(FormMapper $formMapper)
@@ -34,34 +32,5 @@ class BaseBlockEntityAdmin extends BaseAdmin
                 'config_name' => 'admin',
             ])
             ->end();
-    }
-
-    /**
-     * @param \Sonata\AdminBundle\Datagrid\ListMapper $listMapper
-     *
-     * @return void
-     */
-    protected function configureListFields(ListMapper $listMapper)
-    {
-        $listMapper
-            ->add('id')
-            ->add('locale', null, [
-                'label' => 'Langue',
-            ])
-            ->add('name', null, [
-                'label' => 'Nom',
-            ])
-            ->add('dateCreated', null, [
-                'label' => 'Date de création',
-            ])
-            ->add('dateUpdated', null, [
-                'label' => 'Date d\'édition',
-            ])
-            ->add('_action', 'actions', [
-                'actions' => [
-                    'editContent' => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_edit.html.twig'],
-                    'delete'      => [],
-                ],
-            ]);
     }
 }

--- a/Admin/BaseNodeEntityAdmin.php
+++ b/Admin/BaseNodeEntityAdmin.php
@@ -3,25 +3,16 @@
 namespace Alpixel\Bundle\CMSBundle\Admin;
 
 use Alpixel\Bundle\CMSBundle\Form\DateTimeSingleType;
-use Sonata\AdminBundle\Datagrid\DatagridMapper;
-use Sonata\AdminBundle\Datagrid\ListMapper;
+use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 
-class BaseNodeEntityAdmin extends BaseAdmin
+abstract class BaseNodeEntityAdmin extends BaseAdmin
 {
-    protected $baseRouteName = 'alpixel_admin_cms_node';
-    protected $baseRoutePattern = 'node';
-    protected $datagridValues = [
-        '_page'       => 1,
-        '_sort_order' => 'DESC',
-        '_sort_by'    => 'dateUpdated',
-    ];
-
     protected function configureRoutes(RouteCollection $collection)
     {
-        $collection->add('editContent', $this->getRouterIdParameter().'/edit/node');
+        $collection->clearExcept(['add', 'edit', 'delete']);
+        $collection->add('see', $this->getRouterIdParameter().'/see');
         $collection->add('createTranslation', $this->getRouterIdParameter().'/translate');
     }
 
@@ -33,15 +24,40 @@ class BaseNodeEntityAdmin extends BaseAdmin
                 'required' => true,
             ])
             ->add('content', 'ckeditor', [
-                'label' => 'Contenu',
-                'required' => false,
+                'label'       => 'Contenu',
+                'required'    => false,
                 'config_name' => 'admin',
             ]);
+    }
+
+    public function buildBreadcrumbs($action, MenuItemInterface $menu = null)
+    {
+        if (isset($this->breadcrumbs[$action])) {
+            return $this->breadcrumbs[$action];
+        }
+
+        $contentTypes = $this->getCMSTypes();
+        $menu = $this->menuFactory->createItem('root');
+
+        $menu = $menu->addChild('Dashboard',
+            ['uri' => $this->routeGenerator->generate('sonata_admin_dashboard')]
+        );
+
+        $menu = $menu->addChild('Gestion des pages',
+            ['uri' => $this->routeGenerator->generate('alpixel_admin_cms_node_list')]
+        );
+
+        $menu = $menu->addChild(sprintf('Gestion des pages de type "%s"', $contentTypes[$this->getSubject()->getType()]['title']),
+            ['uri' => $this->routeGenerator->generate('alpixel_admin_cms_node_list')]
+        );
+
+        return $this->breadcrumbs[$action] = $menu;
     }
 
     protected function configureFormFields(FormMapper $formMapper)
     {
         self::configureMainFields($formMapper);
+
         $formMapper
             ->add('locale', 'choice', [
                 'label'    => 'Langue du contenu',
@@ -49,7 +65,7 @@ class BaseNodeEntityAdmin extends BaseAdmin
                 'required' => true,
             ])
             ->add('dateCreated', DateTimeSingleType::class, [
-                'label'    => 'Date de création',
+                'label' => 'Date de création',
             ])
             ->add('published', 'checkbox', [
                 'label'    => 'Publié',
@@ -57,108 +73,7 @@ class BaseNodeEntityAdmin extends BaseAdmin
             ]);
     }
 
-    /**
-     * @param \Sonata\AdminBundle\Datagrid\ListMapper $listMapper
-     *
-     * @return void
-     */
-    protected function configureListFields(ListMapper $listMapper)
+    public function showCustomURL($object = null)
     {
-        $listMapper
-            ->add('locale', null, [
-                'label' => 'Langue',
-            ])
-            ->add('title', null, [
-                'label' => 'Page',
-            ])
-            ->add('type', null, [
-                'label'    => 'Type',
-                'template' => 'AlpixelCMSBundle:admin:fields/list__field_type.html.twig',
-            ])
-            ->add('dateCreated', null, [
-                'label' => 'Date de création',
-            ])
-            ->add('dateUpdated', null, [
-                'label' => 'Date d\'édition',
-            ])
-            ->add('published', null, [
-                'label' => 'Publié',
-            ])
-            ->add('_action', 'actions', [
-                'actions' => [
-                    'Voir'        => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_see.html.twig'],
-                    'editContent' => ['template' => 'AlpixelCMSBundle:admin:fields/list__action_edit.html.twig'],
-                    'delete'      => [],
-                ],
-            ]);
-    }
-
-    /**
-     * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $datagridMapper
-     *
-     * @return void
-     */
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
-    {
-        $container     = $this->getConfigurationPool()->getContainer();
-        $entityManager = $container->get('doctrine.orm.default_entity_manager');
-
-        $datagridMapper
-            ->add('locale', 'doctrine_orm_callback', [
-                'label'   => 'Langue',
-                'callback' => function (ProxyQuery $queryBuilder, $alias, $field, $value) {
-                    if (!$value['value']) {
-                        return false;
-                    }
-
-                    $queryBuilder
-                        ->andWhere($alias.'.locale = :locale')
-                        ->setParameter('locale', $value['value']);
-
-                    return true;
-                },
-            ],
-            'choice',
-            [
-                'choices' => $this->getRealLocales(),
-            ])
-            ->add('title', null, [
-                'label' => 'Page',
-            ])
-            ->add('published', null, [
-                'label' => 'Publié',
-            ])
-            ->add('node', 'doctrine_orm_callback', [
-                'label'    => 'Type de contenu',
-                'callback' => function (ProxyQuery $queryBuilder, $alias, $field, $value) use ($entityManager) {
-                    if (!$value['value']) {
-                        return false;
-                    }
-
-                    // We can't query the type from the AlpixelCMSBundle:Node repository (InheritanceType) because of that
-                    // we try to get the repository in AppBundle with the value which is the class name of entity. :pig:
-                    try {
-                        $repository = $entityManager->getRepository(sprintf('AppBundle:%s', ucfirst($value['value'])));
-                    } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
-                        return false;
-                    }
-
-                    $data = $repository->findAll();
-                    if (empty($data)) {
-                        return false;
-                    }
-
-                    $queryBuilder
-                        ->andWhere($alias.'.id IN (:ids)')
-                        ->setParameter('ids', $data);
-
-                    return true;
-                },
-            ],
-                'choice',
-                [
-                    'choices' => $this->getCMSEntityTypes(),
-                ]
-            );
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,25 @@
 services:
+
+    alpixel_cms.twig.extension.text:
+        class: Alpixel\Bundle\CMSBundle\Twig\Extension\TextExtension
+        tags:
+            - { name: twig.extension }
+
+    twig.extension.intl:
+        class: Twig_Extensions_Extension_Intl
+        tags:
+            - { name: twig.extension }
+
+    twig.extension.debug:
+        class: Twig_Extension_Debug
+        tags:
+            - { name: twig.extension }
+
+    twig.extension.date:
+        class: Twig_Extensions_Extension_Date
+        tags:
+            - { name: twig.extension }
+
     alpixel_cms.twig.extension.cms:
         class: Alpixel\Bundle\CMSBundle\Twig\Extension\CMSExtension
         arguments:
@@ -69,7 +90,7 @@ services:
             - { name: doctrine.event_subscriber, connection: default }
 
     alpixel_cms.admin.node:
-        class: Alpixel\Bundle\CMSBundle\Admin\BaseNodeEntityAdmin
+        class: Alpixel\Bundle\CMSBundle\Admin\AdminNode
         arguments:
             - ~
             - Alpixel\Bundle\CMSBundle\Entity\Node
@@ -80,7 +101,7 @@ services:
             - [ setTemplate, [layout, AlpixelCMSBundle:admin:page/base.html.twig]]
 
     alpixel_cms.admin.block:
-        class: Alpixel\Bundle\CMSBundle\Admin\BaseBlockEntityAdmin
+        class: Alpixel\Bundle\CMSBundle\Admin\AdminBlock
         arguments:
             - ~
             - Alpixel\Bundle\CMSBundle\Entity\Block

--- a/Resources/views/admin/fields/list__action_delete.html.twig
+++ b/Resources/views/admin/fields/list__action_delete.html.twig
@@ -1,0 +1,8 @@
+{% set contentTypes = admin.getContentTypes() %}
+{% for key,contentType in contentTypes %}
+    {% if key == object.type and contentType.admin.hasRoute('delete') %}
+    <a class="btn btn-sm btn-danger edit_link" href="{{ contentType.admin.generateObjectUrl('delete', object) }}">
+        <i class="glyphicon glyphicon-trash"></i> Supprimer
+    </a>
+    {% endif %}
+{% endfor %}

--- a/Resources/views/admin/fields/list__action_edit.html.twig
+++ b/Resources/views/admin/fields/list__action_edit.html.twig
@@ -1,3 +1,8 @@
-<a class="btn btn-sm btn-default edit_link" href="{{ admin.generateObjectUrl('editContent', object) }}">
-    <i class="glyphicon glyphicon-edit"></i> Modifier
-</a>
+{% set contentTypes = admin.getContentTypes() %}
+{% for key,contentType in contentTypes %}
+    {% if key == object.type and contentType.admin.hasRoute('edit') %}
+        <a class="btn btn-sm btn-default edit_link" href="{{ contentType.admin.generateObjectUrl('edit', object) }}">
+            <i class="glyphicon glyphicon-pencil"></i> Modifier
+        </a>
+    {% endif %}
+{% endfor %}

--- a/Resources/views/admin/fields/list__action_see.html.twig
+++ b/Resources/views/admin/fields/list__action_see.html.twig
@@ -1,3 +1,9 @@
-<a class="btn btn-sm btn-default edit_link" href="{{path('alpixel_cms', {_locale: object.locale, slug: object.slug})}}" target='_blank'>
-    <i class="glyphicon glyphicon-eye-open"></i> Voir
-</a>
+{% set contentTypes = admin.getContentTypes() %}
+{% for key,contentType in contentTypes %}
+    {% if key == object.type and contentType.admin.hasRoute('see') %}
+        <a class="btn btn-sm btn-info edit_link"
+           href="{{ contentType.admin.generateObjectUrl('see', object) }}" target='_blank'>
+            <i class="glyphicon glyphicon-eye-open"></i> Voir
+        </a>
+    {% endif %}
+{% endfor %}

--- a/Resources/views/admin/fields/list__block_action_edit.html.twig
+++ b/Resources/views/admin/fields/list__block_action_edit.html.twig
@@ -1,0 +1,8 @@
+{% set contentTypes = admin.getBlockTypes() %}
+{% for key,contentType in contentTypes %}
+    {% if object|get_class == contentType.class and key ==  object.slug %}
+        <a class="btn btn-sm btn-default edit_link" href="{{ admin.generateObjectUrl('edit', object) }}">
+            <i class="glyphicon glyphicon-pencil"></i> Modifier
+        </a>
+    {% endif %}
+{% endfor %}

--- a/Resources/views/admin/page/base.html.twig
+++ b/Resources/views/admin/page/base.html.twig
@@ -46,7 +46,7 @@
                 <div class="modal-body">
                     {% if cmsContentType is defined %}
                         {% for type in cmsContentType %}
-                            {% if type.admin is defined %}
+                            {% if type.admin is defined and type.admin.hasRoute('create') %}
                                 <p>
                                     <strong>{{type.title}}</strong>
                                     <br>

--- a/Resources/views/admin/page/base_edit.html.twig
+++ b/Resources/views/admin/page/base_edit.html.twig
@@ -2,7 +2,7 @@
 
 {% block title %}
     {% if admin.id(object) is not null %}
-        {{ "title_edit"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataAdminBundle') }}
+        {{ "title_edit"|trans({'%name%': admin.toString(object) }, 'SonataAdminBundle') }}
     {% else %}
         {{ "title_create"|trans({}, 'SonataAdminBundle') }}
     {% endif %}

--- a/Resources/views/admin/page/base_edit_form.html.twig
+++ b/Resources/views/admin/page/base_edit_form.html.twig
@@ -80,7 +80,7 @@
                                         {% set translationLink = admin.generateUrl('edit', {id: translation.id}) %}
                                     {% else %}
                                         {% set translationLabel = "Traduire en" %}
-                                        {% set translationLink = sonata_admin.url('alpixel_cms.admin.node', 'createTranslation', {
+                                        {% set translationLink = admin.generateUrl('createTranslation', {
                                             id: object.id,
                                             locale: language
                                         }) %}

--- a/Twig/Extension/TextExtension.php
+++ b/Twig/Extension/TextExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Alpixel\Bundle\CMSBundle\Twig\Extension;
+
+class TextExtension extends \Twig_Extension
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'alpixel_text_extension';
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('get_class', [$this, 'getClass']),
+        ];
+    }
+
+    public function getClass($object)
+    {
+        return get_class($object);
+    }
+}


### PR DESCRIPTION
We were using the BaseNodeEntityAdmin for both the "Node" view and the subitems actions (edit/delete/...). That was wrong and it has been edited.
There was a main admin node dispatching the actions via the editContent route. This was an old feature from the days we were not using doctrine inheritance. Those old functionnality were deleted and replaced by delegating the action to every admin (which inherits from the BaseNodeEntityAdmin). Less code and more scalability 👍 
