### PR TITLE
Add deleted configuration in services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -134,6 +134,15 @@ services:
         calls:
             - [ setTemplate, [edit, AlpixelCMSBundle:admin:page/base_edit.html.twig]]
 
+    alpixel_cms.admin.command.loco_translation:
+        class: Alpixel\Bundle\CMSBundle\Admin\AdminTranslation
+        arguments:
+            - ~
+            - ~
+            - 'AlpixelCMSBundle:AdminTranslation'
+        tags:
+            - {name: sonata.admin, manager_type: orm, group: 'CMS', label: 'Gestion des traductions'}
+
     # Sonata block
 
     alpixel_cms.sonata.admin.block.hello:


### PR DESCRIPTION
Added deleted configuration in services.yml (enable the command to download translation from loco in sonata admin)

:chicken: :chicken: :chicken: